### PR TITLE
Release v1.2.0

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -188,6 +188,17 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 			}
 			v = v.Elem()
 		}
+
+		// alloc embedded structs
+		if v.Type().Kind() == reflect.Struct {
+			for i := 0; i < v.NumField(); i++ {
+				field := v.Field(i)
+				if field.Type().Kind() == reflect.Ptr && field.IsNil() && v.Type().Field(i).Anonymous == true {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+			}
+		}
+
 		v = v.FieldByName(name)
 	}
 	// Don't even bother for unexported fields.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1985,3 +1985,42 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
 	}
 }
+
+type S23n struct {
+	F2 string `schema:"F2"`
+	F3 string `schema:"F3"`
+}
+
+type S23e struct {
+	*S23n
+	F1 string `schema:"F1"`
+}
+
+type S23 []*S23e
+
+func TestUnmashalPointerToEmbedded(t *testing.T) {
+	data := map[string][]string{
+		"A.0.F2": []string{"raw a"},
+		"A.0.F3": []string{"raw b"},
+	}
+
+	// Implements encoding.TextUnmarshaler, should not throw invalid path
+	// error.
+	s := struct {
+		Value S23 `schema:"A"`
+	}{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+
+	expected := S23{
+		&S23e{
+			S23n: &S23n{"raw a", "raw b"},
+		},
+	}
+	if !reflect.DeepEqual(expected, s.Value) {
+		t.Errorf("Expected %v errors, got %v", expected, s.Value)
+	}
+}

--- a/encoder.go
+++ b/encoder.go
@@ -57,6 +57,13 @@ func isZero(v reflect.Value) bool {
 		}
 		return z
 	case reflect.Struct:
+		type zero interface {
+			IsZero() bool
+		}
+		if v.Type().Implements(reflect.TypeOf((*zero)(nil)).Elem()) {
+			iz := v.MethodByName("IsZero").Call([]reflect.Value{})[0]
+			return iz.Interface().(bool)
+		}
 		z := true
 		for i := 0; i < v.NumField(); i++ {
 			z = z && isZero(v.Field(i))


### PR DESCRIPTION
Здесь 1 коммит, который исправляет работу такого encoder:
```
encoder := NewEncoder()
encoder.RegisterEncoder(time.Time{}, func(value reflect.Value) string {
    return value.Interface().(time.Time).Format(time.RFC3339Nano)
})
```